### PR TITLE
Add color theme selector (dark mode)

### DIFF
--- a/example/www/index.html
+++ b/example/www/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class="monaco-editor">
 
 <head>
   <meta name="viewport" content="width=device-width, user-scalable=no" />
@@ -357,6 +357,15 @@
         <span class="text-fragment settings"><input type="checkbox" id="show-experimental">Show experiments</span>
         
         <span class="spacer settings"></span>
+
+        <span class="text-fragment settings">
+          <label for="set-theme">Theme:</label>
+          <select name="set-theme" id="set-theme">
+            <option value="2">OS</option>
+            <option value="1">Dark</option>
+            <option value="0">Light</option>
+          </select>
+        </span>
       </div>
       <div id="viewer" tabindex="0"></div>
       <span id="features" class="features"></span>

--- a/example/www/main.js
+++ b/example/www/main.js
@@ -439,6 +439,27 @@ function pollCameraChanges() {
   }, 1000); // TODO only if active tab
 }
 
+const setTheme = ( () => {
+  let html = document.querySelector('html'),
+    select = document.querySelector('select#set-theme'),
+    theme = {
+      editor: ['vs', 'vs-dark'],
+      html: ['light', 'dark']
+    };
+  const getPrefersColor = () => (window.matchMedia('(prefers-color-scheme: dark)').matches) ? 1 : 0,
+    set = (value) => {
+      value = (isNaN(+value) || value > 1) ? 2 : +value
+      let scheme = (value > 1) ? getPrefersColor() : value
+      html.style.colorScheme = theme.html[scheme]
+      monaco.editor.setTheme(theme.editor[scheme])
+      window.localStorage.prefersColor = value
+      return {value, scheme}
+    };
+  select.value = set(window.localStorage.prefersColor ?? 2).value
+  select.oninput = () => set(select.value)
+  return set
+})();
+
 try {
   const workingDir = '/home';
   const fs = await createEditorFS(workingDir);


### PR DESCRIPTION
I've added the color scheme selector that saves the selected theme to `localStorage` and applies it on page reload.

![ochafik com_openscad_](https://user-images.githubusercontent.com/66020883/163660598-1b65f97b-f398-4faa-8ca2-c329a7a77820.png)

