### PR TITLE
Enable buildkit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 res
 !res/fonts
 *.make
+.oci.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
-ARG DOCKER_TAG_BASE=openscad-base
+ARG DOCKER_TAG_BASE=openscad/wasm-base
 
 FROM ${DOCKER_TAG_BASE}
 
 ARG EMSCRIPTEN_FLAGS=""
 ARG CMAKE_BUILD_TYPE=Release
+ARG CMAKE_BUILD_PARALLEL_LEVEL=4
+
+RUN apt-get update && apt-get -y full-upgrade
+
+RUN apt-get install -y --no-install-recommends ninja-build
 
 ENV CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
 ENV CMAKE_C_FLAGS="${EMSCRIPTEN_FLAGS}"
@@ -14,6 +19,8 @@ COPY . .
 RUN emcmake cmake -B ../build . \
         -DBoost_USE_STATIC_RUNTIME=ON \
         -DBoost_USE_STATIC_LIBS=ON \
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
+        -DCMAKE_BUILD_PARALLEL_LEVEL=${CMAKE_BUILD_PARALLEL_LEVEL} \
         -DEXPERIMENTAL=ON \
         -DSNAPSHOT=ON \
         -G Ninja && \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -258,7 +258,7 @@ RUN emcmake cmake \
     cmake --install ../build
 
 
-FROM builder AS openscad-base
+FROM builder AS wasm-base
 COPY --from=boost /emsdk/upstream/emscripten/cache/sysroot /emsdk/upstream/emscripten/cache/sysroot
 COPY --from=gmp /emsdk/upstream/emscripten/cache/sysroot /emsdk/upstream/emscripten/cache/sysroot
 COPY --from=mpfr /emsdk/upstream/emscripten/cache/sysroot /emsdk/upstream/emscripten/cache/sysroot

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -80,6 +80,7 @@ RUN cd expat && \
 FROM builder AS zlib
 COPY zlib .
 RUN emcmake cmake \
+        -DINSTALL_PKGCONFIG_DIR="/emsdk/upstream/emscripten/cache/sysroot/lib/pkgconfig/" \
         -B ../build && \
     cmake --build ../build && \
     cmake --install ../build
@@ -258,6 +259,20 @@ RUN emcmake cmake \
     cmake --install ../build
 
 
+FROM builder AS lib3mf
+COPY --from=zlib /emsdk/upstream/emscripten/cache/sysroot /emsdk/upstream/emscripten/cache/sysroot
+COPY --from=libzip /emsdk/upstream/emscripten/cache/sysroot /emsdk/upstream/emscripten/cache/sysroot
+COPY lib3mf .
+RUN emcmake cmake \
+        -B ../build \
+        -DLIB3MF_TESTS=OFF \
+        -DUSE_INCLUDED_ZLIB=OFF \
+        -DUSE_INCLUDED_LIBZIP=OFF \
+        -G Ninja && \
+    cmake --build ../build --parallel && \
+    cmake --install ../build
+
+
 FROM builder AS wasm-base
 COPY --from=boost /emsdk/upstream/emscripten/cache/sysroot /emsdk/upstream/emscripten/cache/sysroot
 COPY --from=gmp /emsdk/upstream/emscripten/cache/sysroot /emsdk/upstream/emscripten/cache/sysroot
@@ -270,7 +285,7 @@ COPY --from=glib /emsdk/upstream/emscripten/cache/sysroot /emsdk/upstream/emscri
 COPY --from=libzip /emsdk/upstream/emscripten/cache/sysroot /emsdk/upstream/emscripten/cache/sysroot
 COPY --from=libffi /emsdk/upstream/emscripten/cache/sysroot /emsdk/upstream/emscripten/cache/sysroot
 COPY --from=doubleconversion /emsdk/upstream/emscripten/cache/sysroot /emsdk/upstream/emscripten/cache/sysroot
+COPY --from=lib3mf /emsdk/upstream/emscripten/cache/sysroot /emsdk/upstream/emscripten/cache/sysroot
 # COPY --from=freetype /emsdk/upstream/emscripten/cache/sysroot /emsdk/upstream/emscripten/cache/sysroot
 # COPY --from=cairo /emsdk/upstream/emscripten/cache/sysroot /emsdk/upstream/emscripten/cache/sysroot
 # COPY --from=libexpat /emsdk/upstream/emscripten/cache/sysroot /emsdk/upstream/emscripten/cache/sysroot
-# COPY --from=lib3mf /emsdk/upstream/emscripten/cache/sysroot /emsdk/upstream/emscripten/cache/sysroot

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,8 @@ libs/harfbuzz:
 	git clone https://github.com/harfbuzz/harfbuzz.git ${SHALLOW} ${SINGLE_BRANCH_MAIN} $@
 
 libs/lib3mf:
-	git clone --recurse https://github.com/3MFConsortium/lib3mf.git ${SHALLOW} ${SINGLE_BRANCH} $@
+	git clone --recurse https://github.com/3MFConsortium/lib3mf.git ${SHALLOW} --branch v2.3.2 $@
+	git -C $@ apply ../../patches/lib3mf.patch
 
 libs/libexpat:
 	git clone  https://github.com/libexpat/libexpat ${SHALLOW} ${SINGLE_BRANCH} $@

--- a/Makefile
+++ b/Makefile
@@ -206,10 +206,10 @@ libs/boost:
 	sed -i -E 's/-fwasm-exceptions/-fexceptions/g' libs/boost/tools/build/src/tools/emscripten.jam
 
 libs/gmp:
-	wget https://gmplib.org/download/gmp/gmp-6.3.0.tar.lz 
-	tar --lzma -xf gmp-6.3.0.tar.lz -C libs
+	wget https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz
+	tar xf gmp-6.3.0.tar.xz -C libs
 	mv libs/gmp-6.3.0 $@
-	rm gmp-6.3.0.tar.lz
+	rm gmp-6.3.0.tar.xz
 
 libs/mpfr:
 	wget https://www.mpfr.org/mpfr-4.2.1/mpfr-4.2.1.tar.xz

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Make sure that you have the following installed:
 - Make
 - Docker
 - Deno
-- lzip (might be missing on some distros)
 
 To build the project:
 

--- a/patches/lib3mf.patch
+++ b/patches/lib3mf.patch
@@ -1,0 +1,16 @@
+diff --git a/Include/API/lib3mf_model.hpp b/Include/API/lib3mf_model.hpp
+index d491ea08..d28594d4 100644
+--- a/Include/API/lib3mf_model.hpp
++++ b/Include/API/lib3mf_model.hpp
+@@ -195,9 +195,9 @@ public:
+ 
+ 	Lib3MF::sBox GetOutbox() override;
+ 
+-	IKeyStore * GetKeyStore();
++	IKeyStore * GetKeyStore() override;
+ 
+-	void SetRandomNumberCallback(const Lib3MF::RandomNumberCallback pTheCallback, const Lib3MF_pvoid pUserData);
++	void SetRandomNumberCallback(const Lib3MF::RandomNumberCallback pTheCallback, const Lib3MF_pvoid pUserData) override;
+ };
+ 
+ }


### PR DESCRIPTION
* Drop dependency on `lzip`
* Default to official tag names used on docker hub
* Add option to build via buildkit (`make BUILDKIT=1`)
* Build lib3mf version 2.3.2.
